### PR TITLE
fix: minor behavior-related issue in race and individual round 

### DIFF
--- a/api/src/main/java/net/starype/quiz/api/game/ClassicalRound.java
+++ b/api/src/main/java/net/starype/quiz/api/game/ClassicalRound.java
@@ -43,7 +43,7 @@ public class ClassicalRound implements GameRound {
         counter.incrementGuess(source);
         leaderboard.scoreUpdate(source, correctness);
 
-        if(Math.abs(correctness - 1) < 0.001) {
+        if(Math.abs(correctness - 1) < ScoreDistribution.EPSILON) {
             counter.consumeAllGuesses(source);
         }
 

--- a/api/src/main/java/net/starype/quiz/api/game/FixedLeaderboardEnding.java
+++ b/api/src/main/java/net/starype/quiz/api/game/FixedLeaderboardEnding.java
@@ -27,7 +27,7 @@ public class FixedLeaderboardEnding implements RoundEndingPredicate {
         }
         return leaderboard
                 .stream()
-                .allMatch((seat) -> Math.abs(seat.getScore() - 1) < 0.001);
+                .allMatch((seat) -> Math.abs(seat.getScore() - 1) < ScoreDistribution.EPSILON);
     }
 
     private boolean fullAndOneBelow() {
@@ -36,7 +36,7 @@ public class FixedLeaderboardEnding implements RoundEndingPredicate {
         }
         return leaderboard
                 .stream()
-                .filter((seat) -> Math.abs(seat.getScore() - 1) > 0.001)
+                .filter((seat) -> Math.abs(seat.getScore() - 1) > ScoreDistribution.EPSILON)
                 .count() == 1;
     }
 }

--- a/api/src/main/java/net/starype/quiz/api/game/IndividualRound.java
+++ b/api/src/main/java/net/starype/quiz/api/game/IndividualRound.java
@@ -46,6 +46,7 @@ public class IndividualRound implements GameRound {
     @Override
     public void onGiveUpReceived(IDHolder<?> source) {
         scoreDistribution.addIfNew(source, 0);
+        maxGuessCounter.consumeAllGuesses(source);
     }
 
     @Override

--- a/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
+++ b/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
@@ -43,7 +43,7 @@ public class RaceRound implements GameRound {
         if(correctness.isEmpty()) {
             return new PlayerGuessContext(source, 0, true);
         }
-        boolean binaryCorrectness = Math.abs(correctness.get() - 1) < 0.001;
+        boolean binaryCorrectness = Math.abs(correctness.get() - 1) < ScoreDistribution.EPSILON;
 
         counter.incrementGuess(source);
         if(binaryCorrectness) {

--- a/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
+++ b/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
@@ -40,7 +40,10 @@ public class RaceRound implements GameRound {
 
         // eligibility checks are performed in the game class
         Optional<Double> correctness = pickedQuestion.evaluateAnswer(Answer.fromString(message));
-        boolean binaryCorrectness = Math.abs(correctness.orElse(0D) - 1) < 0.01;
+        if(correctness.isEmpty()) {
+            return new PlayerGuessContext(source, 0, true);
+        }
+        boolean binaryCorrectness = Math.abs(correctness.orElse(0D) - 1) < 0.001;
 
         counter.incrementGuess(source);
         if(binaryCorrectness) {

--- a/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
+++ b/api/src/main/java/net/starype/quiz/api/game/RaceRound.java
@@ -43,7 +43,7 @@ public class RaceRound implements GameRound {
         if(correctness.isEmpty()) {
             return new PlayerGuessContext(source, 0, true);
         }
-        boolean binaryCorrectness = Math.abs(correctness.orElse(0D) - 1) < 0.001;
+        boolean binaryCorrectness = Math.abs(correctness.get() - 1) < 0.001;
 
         counter.incrementGuess(source);
         if(binaryCorrectness) {

--- a/api/src/main/java/net/starype/quiz/api/game/ScoreDistribution.java
+++ b/api/src/main/java/net/starype/quiz/api/game/ScoreDistribution.java
@@ -10,6 +10,8 @@ import java.util.function.Function;
 
 public interface ScoreDistribution extends Function<Player<?>, Double> {
 
+    double EPSILON = 0.001;
+
     default Map<Player<?>, Double> applyAll(Collection<? extends Player<?>> players, BiConsumer<Player<?>, Double> action) {
         Map<Player<?>, Double> standings = new HashMap<>();
         for(Player<?> player : players) {

--- a/api/src/main/java/net/starype/quiz/api/game/answer/BinaryLossFunction.java
+++ b/api/src/main/java/net/starype/quiz/api/game/answer/BinaryLossFunction.java
@@ -1,5 +1,7 @@
 package net.starype.quiz.api.game.answer;
 
+import net.starype.quiz.api.game.ScoreDistribution;
+
 public class BinaryLossFunction implements LossFunction {
     private double threshold = .5;
 
@@ -8,7 +10,7 @@ public class BinaryLossFunction implements LossFunction {
     }
 
     public BinaryLossFunction() {
-        this(0.001);
+        this(ScoreDistribution.EPSILON);
     }
 
     @Override

--- a/api/src/main/java/net/starype/quiz/api/game/answer/WordValidityEvaluator.java
+++ b/api/src/main/java/net/starype/quiz/api/game/answer/WordValidityEvaluator.java
@@ -18,6 +18,6 @@ public class WordValidityEvaluator implements ValidityEvaluator {
     public boolean isValid(Answer answer) {
         return answer
                 .getAnswerText()
-                .matches("[a-zA-Z'0-9]+");
+                .matches("[a-zA-Z'0-9\\-]+");
     }
 }

--- a/api/src/test/java/net/starype/quiz/api/game/RaceRoundTest.java
+++ b/api/src/test/java/net/starype/quiz/api/game/RaceRoundTest.java
@@ -34,7 +34,7 @@ public class RaceRoundTest {
         GameRoundContext context = round.getContext();
 
         for(Player<?> player : players) {
-            round.onGuessReceived(player, "INCORRECT ANSWER");
+            round.onGuessReceived(player, "INCORRECT-ANSWER");
         }
 
         Assert.assertTrue(context.getEndingCondition().ends());


### PR DESCRIPTION
* `IndividualRound` wouldn't consume all the guesses in case of a give up, messing up the round ending predicate
* `RaceRound` considered that an invalid answer was identical to a wrong answer, which should not be the case